### PR TITLE
Sync upstream IGHTMLQuery version -> 0.9.1

### DIFF
--- a/lib/motion-html.rb
+++ b/lib/motion-html.rb
@@ -10,6 +10,6 @@ lib_dir_path = File.dirname(File.expand_path(__FILE__))
 Motion::Project::App.setup do |app|
   app.files.unshift(Dir.glob(File.join(lib_dir_path, "project/**/*.rb")))
   app.pods do
-    pod "IGHTMLQuery", "~> 0.8.4"
+    pod "IGHTMLQuery", "~> 0.9.1"
   end
 end


### PR DESCRIPTION
I got compile error using 0.8.4, after update to 0.9.1 it's ok.