### PR TITLE
Switch from using IGHTMLQuery to HTMLKit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Parse and traverse HTML in your RubyMotion app. It's like Nokogiri for RubyMotion!
 
-Motion::HTML uses [IGHTMLQuery](https://github.com/siuying/IGHTMLQuery) under the hood.
+Motion::HTML uses [HTMLKit](https://github.com/iabudiab/HTMLKit) under the hood.
 
 Currently, only iOS and OS X are supported.
 

--- a/lib/motion-html.rb
+++ b/lib/motion-html.rb
@@ -10,6 +10,6 @@ lib_dir_path = File.dirname(File.expand_path(__FILE__))
 Motion::Project::App.setup do |app|
   app.files.unshift(Dir.glob(File.join(lib_dir_path, "project/**/*.rb")))
   app.pods do
-    pod "IGHTMLQuery", "~> 0.9.1"
+    pod 'HTMLKit', '~> 3.1'
   end
 end

--- a/lib/project/motion-html.rb
+++ b/lib/project/motion-html.rb
@@ -6,18 +6,11 @@ module Motion
 
     class Doc
       def initialize(html)
-        @doc = IGHTMLDocument.alloc.initWithHTMLString(html, error: nil)
+        @doc = HTMLDocument.documentWithString(html)
       end
 
       def query(q)
-        if q =~ %r{^[//|/]}
-          node_set = @doc.queryWithXPath(q)
-        else
-          node_set = @doc.queryWithCSS(q)
-        end
-        nodes = []
-        node_set.enumerateNodesUsingBlock -> (node, index, stop) { nodes << node }
-        nodes
+        nodes = @doc.querySelectorAll(q)
       end
     end
   end


### PR DESCRIPTION
IGHTMLQuery is old and no longer maintained. HTMLKit is newer, currently maintained, and simpler to work with.